### PR TITLE
Add changes to allow installing this package on ARM

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -7,8 +7,10 @@ eos-chrome-plugin-update.service: eos-chrome-plugin-update.service.in
 	@sed -e "s|\@pkglibexecdir\@|$(pkglibexecdir)|" $< > $@
 systemdsystemunit_DATA = eos-chrome-plugin-update.service
 
+if ENABLE_NM_INTEGRATION
 install-data-hook:
 	chmod +x $(DESTDIR)$(sysconfdir)/network/if-up.d/eos-chrome-plugin-update-nm
+endif
 
 EXTRA_DIST = eos-chrome-plugin-update.service.in
 CLEANFILES = eos-chrome-plugin-update.service

--- a/configure.ac
+++ b/configure.ac
@@ -12,6 +12,17 @@ PKG_PROG_PKG_CONFIG
 # systemd
 AC_SUBST([systemdsystemunitdir], [$($PKG_CONFIG --variable=systemdsystemunitdir systemd)])
 
+# optionally disable integration with Network Manager (on ifup events)
+AC_MSG_CHECKING([whether to enable the integration with Network Manager])
+AC_ARG_ENABLE(nm-integration,
+              AC_HELP_STRING([--enable-nm-integration],
+                             [Enable integration with Network Manager [default=yes]]),
+              [enable_nm_integration="$enableval"],
+              [enable_nm_integration="yes"])
+
+AC_MSG_RESULT([$enable_nm_integration])
+AM_CONDITIONAL([ENABLE_NM_INTEGRATION],[test "x$enable_nm_integration" = "xyes"])
+
 AC_CONFIG_FILES([
 Makefile
 ])

--- a/eos-chrome-plugin-update
+++ b/eos-chrome-plugin-update
@@ -113,6 +113,12 @@ fp_remove_old_plugins() {
     rm -rf ${OLD_DIRS}
 }
 
+ARCH=$(arch)
+case ${ARCH} in
+    i?86) ;; # Only 32-bit Intel architectures are supported
+    *) fp_exit_with_error "Unsupported architecture ${ARCH}" ;;
+esac
+
 fp_should_check_update
 fp_find_latest_version
 fp_should_update

--- a/eos-chrome-plugin-update.service.in
+++ b/eos-chrome-plugin-update.service.in
@@ -1,6 +1,9 @@
 [Unit]
 Description=Update or install Google Chrome plugins
 
+# Only 32-bit Intel architectures are supported
+ConditionArchitecture=|x86
+
 [Service]
 Type=simple
 ExecStart=@pkglibexecdir@/eos-chrome-plugin-update


### PR DESCRIPTION
The following changes allow installing the package on ARM so that the only actual stuff that will be used there will be the hooks for chromium under /etc:
  * Only support 32-bit Intel architectures
  * Added a configure option to disable integration with Network Manager

[endlessm/eos-shell#5707]