### PR TITLE
Disable support for 32-bit Intel architectures in the updater script

### DIFF
--- a/eos-chrome-plugin-update-intel
+++ b/eos-chrome-plugin-update-intel
@@ -10,7 +10,7 @@ fi
 
 DEB_ARCH=`dpkg --print-architecture`
 case ${DEB_ARCH} in
-    i386) ;; amd64) ;; # Only Intel architectures are supported
+    amd64) ;; # Only 64-bit Intel architectures are supported
     *) echo "Unsupported architecture ${DEB_ARCH}"
        exit 1
        ;;


### PR DESCRIPTION
Since March 2nd, Google no longer publishes 32-bit binary builds of
Google Chrome, so we disable support for it from now on.

https://phabricator.endlessm.com/T10669