### PR TITLE
Disable integration with Network Manager for i386 as well now

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,13 +43,15 @@ Conflicts: eos-pepflashplugin-updater
 Description: Google Chrome plugin updater/installer
  Downloads and Installs or Upgrades the Pepper Flash and Widevine DRM plugins.
  .
- On Intel, this package will download Chrome from Google, and unpack it to
- make the included Pepper Flash Player and Widevine Encrypted Media Extensions
- DRM available for use with Chromium.
- The end user license agreement is available at Google.
+ On amd64 (the only Intel architecture supported by the updater now that Google no
+ longer ships 32-bit binary packages of Google Chrome), this package will download
+ Chrome from Google, and unpack it to make the included Pepper Flash Player and
+ Widevine Encrypted Media Extensions DRM available for use with Chromium.
  .
- On ARM, this package installs the hooks that allow using those plugins if
+ On armhf, this package installs the hooks that allow using those plugins if
  present, but does not download or install anything automatically for now.
  Instead, it provides a eos-chrome-plugin-update-arm script that can be
  manually run to install the plugins from a ChromeOS image that will be
  downloaded upon explicit confirmation by the user (as it's usually big).
+ .
+ The end user license agreement is available at Google.

--- a/debian/rules
+++ b/debian/rules
@@ -4,9 +4,9 @@ DEB_BUILD_ARCH     ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
 
 EXTRA_PARAMS=
 
-# Disable integration with the Network Manager for non Intel builds,
+# Disable integration with the Network Manager for non Intel 64-bit builds,
 # as the updater is only automatically triggered in those architectures.
-ifeq (,$(filter $(DEB_BUILD_ARCH),i386 amd64))
+ifneq ($(DEB_BUILD_ARCH),amd64)
 	EXTRA_PARAMS += --disable-nm-integration
 endif
 


### PR DESCRIPTION
Since March 2nd, Google no longer publishes 32-bit binary builds of
Google Chrome, so we disable the automatic hook on if-up events as
that the uploader script will no longer work in that architecture.

Still this package is still useful for current installations as it
provides the necessary symlink for the Widevine plugin to work and
the runtime flags for chromium to find the Flash plugin, in case
they are present under /var/lib/chromium-plugins-extra.

https://phabricator.endlessm.com/T10669