### PR TITLE
build: Don't distribute eos-chrome-plugin-update script

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,5 +1,7 @@
+pkglibexec_SCRIPTS = \
+	eos-chrome-plugin-update
+
 dist_pkglibexec_SCRIPTS = \
-	eos-chrome-plugin-update \
 	eos-chrome-plugin-update-intel \
 	eos-chrome-plugin-update-arm
 


### PR DESCRIPTION
This needs to be generated during the build to get the correct
$(pkglibexecdir) substituted. Distributing it causes it not to be
rebuilt.