### PR TITLE
fix racy kpartx invocation

### DIFF
--- a/eos-chrome-plugin-update-arm
+++ b/eos-chrome-plugin-update-arm
@@ -194,7 +194,7 @@ fp_mount_chromeos_partition() {
     [ -n "${LOOP_DEVICE}" ] \
         || fp_exit_with_error "Could not crete a loopback device for ${TEMP_DIR}/${CHROMEOS_FILENAME}"
 
-    kpartx -a "${LOOP_DEVICE}"
+    kpartx -as "${LOOP_DEVICE}"
     mkdir -p "${MNT_DIR}"
 
     # The interesting data is in the third partition


### PR DESCRIPTION
Calling kpartx -a and relying on the device nodes existing immediately afterwards is racy. Add -s to the kpartx command line so it blocks until the device nodes have been created.

https://phabricator.endlessm.com/T13451