### PR TITLE
Unify methods to install Chrome plugins in all platform (debian changes)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -44,15 +44,19 @@ Conflicts: eos-pepflashplugin-updater
 Description: Google Chrome plugin updater/installer
  Downloads and Installs or Upgrades the Pepper Flash and Widevine DRM plugins.
  .
- On amd64 (the only Intel architecture supported by the updater now that Google no
- longer ships 32-bit binary packages of Google Chrome), this package will download
- Chrome from Google, and unpack it to make the included Pepper Flash Player and
- Widevine Encrypted Media Extensions DRM available for use with Chromium.
+ If a base URL is provided via /etc/default/eos-chrome-plugin-update, this package
+ will automatically check for updates of the Chrome plugins there and download them
+ if needed, when the machine goes online. If such an URL is not defined, the updated
+ behaves differently on amd64 and armhf:
  .
- On armhf, this package installs the hooks that allow using those plugins if
- present, but does not download or install anything automatically for now.
- Instead, it provides a eos-chrome-plugin-update-arm script that can be
- manually run to install the plugins from a ChromeOS image that will be
- downloaded upon explicit confirmation by the user (as it's usually big).
+ On amd64, this package will download Chrome from Google, and unpack it to make the
+ included Pepper Flash Player and Widevine Encrypted Media Extensions DRM available
+ for use with Chromium.
+ .
+ On armhf, this package will install the hooks that allow using those plugins if
+ present, but it will not download or install anything automatically. Instead, it
+ provides a eos-chrome-plugin-update-cros script that can be manually run to install
+ the plugins from a ChromeOS image that will be downloaded upon explicit confirmation
+ by the user (as it's usually big).
  .
  The end user license agreement is available at Google.

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Standards-Version: 3.8.0
 Homepage: http://www.endlessm.com
 
 Package: eos-chrome-plugin-updater
-Architecture: any
+Architecture: amd64 armhf
 Depends: ${misc:Depends},
 	${shlibs:Depends},
 	debconf | debconf-2.0,

--- a/debian/control
+++ b/debian/control
@@ -46,7 +46,7 @@ Description: Google Chrome plugin updater/installer
  .
  If a base URL is provided via /etc/default/eos-chrome-plugin-update, this package
  will automatically check for updates of the Chrome plugins there and download them
- if needed, when the machine goes online. If such an URL is not defined, the updated
+ if needed, when the machine goes online. If such an URL is not defined, the updater
  behaves differently on amd64 and armhf:
  .
  On amd64, this package will download Chrome from Google, and unpack it to make the

--- a/debian/rules
+++ b/debian/rules
@@ -1,17 +1,4 @@
 #!/usr/bin/make -f
 
-DEB_BUILD_ARCH     ?= $(shell dpkg-architecture -qDEB_BUILD_ARCH)
-
-EXTRA_PARAMS=
-
-# Disable integration with the Network Manager for non Intel 64-bit builds,
-# as the updater is only automatically triggered in those architectures.
-ifneq ($(DEB_BUILD_ARCH),amd64)
-	EXTRA_PARAMS += --disable-nm-integration
-endif
-
 %:
 	dh $@ --with autoreconf,systemd
-
-override_dh_auto_configure:
-	dh_auto_configure $@ -- $(EXTRA_PARAMS)


### PR DESCRIPTION
Stop disabling the integration with the NetworkManager depending on the platform and update the debian/control file to reflect the new reality.

https://phabricator.endlessm.com/T13597