### PR TITLE
add a list of products where the automatic download is disabled

### DIFF
--- a/eos-chrome-plugin-update.in
+++ b/eos-chrome-plugin-update.in
@@ -10,6 +10,7 @@ UPDATER_CONF_FILE="@sysconfdir@/default/eos-chrome-plugin-update"
 # To be defined below
 DOWNLOAD_URL=
 UPDATER_COMMAND=
+DISABLED_PRODUCTS="fixme"
 
 # Check whether there's a custom URL defined first
 if [ -f "${UPDATER_CONF_FILE}" ]; then
@@ -20,6 +21,21 @@ if [ -f "${UPDATER_CONF_FILE}" ]; then
         esac
     done < ${UPDATER_CONF_FILE}
 fi
+
+# Read "eos-image-version" attr from /sysroot or / to find product
+image=$(attr -q -g eos-image-version /sysroot 2>/dev/null ) || true
+if [ "${image}" = "" ]; then
+    image=$(attr -q -g eos-image-version / 2>/dev/null ) || true
+fi
+product=$(echo "${image}" | cut -d- -f1)
+
+# Skip plugin download on disabled products
+for p in ${DISABLED_PRODUCTS}; do
+    if [ "${p}" = "${product}" ]; then
+        echo "Automatic updater disabled on ${product} product."
+        exit 0
+    fi
+done
 
 if [ -n "${DOWNLOAD_URL}" ]; then
     # Need to include the URL along with the command


### PR DESCRIPTION
This is for certain deployments which are known to have internet
connectivity, but it is very constrained, such that having all of
the computers attempting to download Chrome & various plugins would
consume an undesirably high amount of bandwidth. Unless/until a
more bandwidth-efficient solution is available, disable the
download on these images by matching the product name. This allows
the change to be reverted at some point in the future by updating
the script. (Disabling the script / systemd jobs in configuration
would be far harder to reverse over the air.)

https://phabricator.endlessm.com/T15547