### PR TITLE
avoid plugin download when local firewall is active

### DIFF
--- a/eos-chrome-plugin-update.in
+++ b/eos-chrome-plugin-update.in
@@ -10,6 +10,7 @@ UPDATER_CONF_FILE="@sysconfdir@/default/eos-chrome-plugin-update"
 # To be defined below
 DOWNLOAD_URL=
 UPDATER_COMMAND=
+FIREWALL_SERVICE="eos-firewall-localonly.service"
 
 # Check whether there's a custom URL defined first
 if [ -f "${UPDATER_CONF_FILE}" ]; then
@@ -19,6 +20,18 @@ if [ -f "${UPDATER_CONF_FILE}" ]; then
             *) ;;
         esac
     done < ${UPDATER_CONF_FILE}
+fi
+
+# Skip plugin download if firewall service is active or enabled.
+# This double-check is intentional: you have to not only stop the
+# firewall but explicitly disable it for this script to function.
+# We want to avoid accidentally retreiving the plugin once during
+# some unrelated local administration task, but not being able to
+# update it in future.
+if systemctl is-active -q ${FIREWALL_SERVICE} ||
+   systemctl is-enabled -q ${FIREWALL_SERVICE}; then
+    echo "Automatic updater disabled as ${FIREWALL_SERVICE} is active or enabled."
+    exit 0
 fi
 
 if [ -n "${DOWNLOAD_URL}" ]; then


### PR DESCRIPTION
This is for certain deployments which are known to have internet
connectivity, but it is very constrained, such that having all of the
computers attempting to download Chrome & various plugins would consume
an undesirably high amount of bandwidth. These systems have a local
firewall which prevents general access to the internet. To avoid logging
confusing/distracting errors, gracefully disable this script when we know
the firewall will cause it to fail.

Note that as well as disabling this script in the case that the firewall
is running, we also disable it in the case that the firewall is enabled -
we don't want to automatically download the plugin during some unrelated
administration task if we're also not confident that normal connectivity
will be available in future to keep it up to date.

https://phabricator.endlessm.com/T15547