### PR TITLE
T21987: use separate temp dirs for flash and widevine

### DIFF
--- a/eos-chrome-plugin-update-upstream
+++ b/eos-chrome-plugin-update-upstream
@@ -17,6 +17,10 @@ case ${DEB_ARCH} in
 esac
 
 TEMP_DIR=`mktemp -d`
+FLASH_TEMP_DIR="${TEMP_DIR}/flash"
+WIDEVINE_TEMP_DIR="${TEMP_DIR}/widevine"
+mkdir -p "${FLASH_TEMP_DIR}" "${WIDEVINE_TEMP_DIR}"
+
 DEST_DIR=/var/lib/chromium-plugins-extra/eos-chrome-plugin-updater
 WGET_COMMAND="wget -c --tries=5"
 DAYS_CHECK=7
@@ -153,7 +157,7 @@ fp_should_check_updates_widevine() {
 
 fp_fetch_flash_metadata() {
     local filename=$(basename ${FLASH_LKGV_FILE_URL})
-    if ${WGET_COMMAND} "${FLASH_LKGV_FILE_URL}" -O "${TEMP_DIR}/${filename}"; then
+    if ${WGET_COMMAND} "${FLASH_LKGV_FILE_URL}" -O "${FLASH_TEMP_DIR}/${filename}"; then
         while IFS='=' read key value; do
             case "$key" in
                 "VERSION") FLASH_LKGV_VERSION="$value" ;;
@@ -161,7 +165,7 @@ fp_fetch_flash_metadata() {
                 "SHA256SUM") FLASH_LKGV_SHA256SUM="$value" ;;
                 *) ;;
             esac
-        done < ${TEMP_DIR}/${filename}
+        done < ${FLASH_TEMP_DIR}/${filename}
     else
         echo "Failed to retrieve the last known good version of the flash plugin"
         echo "Using fallbacks values (Flash plugin version: ${FLASH_FALLBACK_VERSION})"
@@ -177,12 +181,12 @@ fp_fetch_flash_metadata() {
 
 fp_fetch_widevine_metadata() {
     local filename=$(basename ${WIDEVINE_VERSION_URL})
-    if ! ${WGET_COMMAND} "${WIDEVINE_VERSION_URL}" -O "${TEMP_DIR}/${filename}"; then
+    if ! ${WGET_COMMAND} "${WIDEVINE_VERSION_URL}" -O "${WIDEVINE_TEMP_DIR}/${filename}"; then
         echo "Failed to download current Widevine version"
         return 1
     fi
 
-    WIDEVINE_VERSION_CURRENT=$(cat ${TEMP_DIR}/${filename})
+    WIDEVINE_VERSION_CURRENT=$(cat ${WIDEVINE_TEMP_DIR}/${filename})
     WIDEVINE_URL=${WIDEVINE_BASE_URL}/${WIDEVINE_VERSION_CURRENT}-linux-x64.zip
     WIDEVINE_FILENAME=$(basename ${WIDEVINE_URL})
 }
@@ -223,7 +227,7 @@ fp_should_update_widevine() {
 
 fp_download_widevine() {
     echo "Downloading ${WIDEVINE_FILENAME}"
-    if ! ${WGET_COMMAND} "${WIDEVINE_URL}" -O "${TEMP_DIR}/${WIDEVINE_FILENAME}"; then
+    if ! ${WGET_COMMAND} "${WIDEVINE_URL}" -O "${WIDEVINE_TEMP_DIR}/${WIDEVINE_FILENAME}"; then
         echo "Failed to download ${WIDEVINE_FILENAME}"
         return 1
     fi
@@ -234,27 +238,27 @@ fp_download_widevine() {
 fp_download_adobe_flash() {
     # Get the Adobe Flash Plugin
     echo "Downloading ${FLASH_LKGV_FILENAME}"
-    if ! ${WGET_COMMAND} "${FLASH_LKGV_URL}" -O "${TEMP_DIR}/${FLASH_LKGV_FILENAME}"; then
+    if ! ${WGET_COMMAND} "${FLASH_LKGV_URL}" -O "${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME}"; then
         echo "Failed to download ${FLASH_LKGV_URL}"
         return 1
     fi
 
     # Verify SHA256 checksum of debian file
-    echo "Verifying ${TEMP_DIR}/${FLASH_LKGV_FILENAME}"
-    echo "${FLASH_LKGV_SHA256SUM} ${TEMP_DIR}/${FLASH_LKGV_FILENAME}" | sha256sum -c > /dev/null 2>&1 || \
+    echo "Verifying ${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME}"
+    echo "${FLASH_LKGV_SHA256SUM} ${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME}" | sha256sum -c > /dev/null 2>&1 || \
     {
-        echo "sha256sum mismatch ${TEMP_DIR}/${FLASH_LKGV_FILENAME}"
+        echo "sha256sum mismatch ${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME}"
         return 1
     }
 }
 
 fp_install_flash_plugin() {
-    echo "Installing ${TEMP_DIR}/${FLASH_LKGV_FILENAME}"
-    if ! tar zxv -C ${TEMP_DIR} -f ${TEMP_DIR}/${FLASH_LKGV_FILENAME} ; then
+    echo "Installing ${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME}"
+    if ! tar zxv -C ${FLASH_TEMP_DIR} -f ${FLASH_TEMP_DIR}/${FLASH_LKGV_FILENAME} ; then
         echo "Cannot extract files from ${FLASH_LKGV_FILENAME}"
-    elif ! [ -f ${TEMP_DIR}/${FLASH_SO_FILE} ]; then
+    elif ! [ -f ${FLASH_TEMP_DIR}/${FLASH_SO_FILE} ]; then
         echo "Could not find ${FLASH_SO_FILE}"
-    elif ! install -m 644 ${TEMP_DIR}/${FLASH_SO_FILE} ${DEST_DIR} ; then
+    elif ! install -m 644 ${FLASH_TEMP_DIR}/${FLASH_SO_FILE} ${DEST_DIR} ; then
         echo "Could not copy ${FLASH_SO_FILE} into ${DEST_DIR}"
     else
         # Sanity check: don't ever write a VERSION file with an empty value
@@ -269,12 +273,12 @@ fp_install_flash_plugin() {
 }
 
 fp_install_widevine_plugin() {
-    echo "Installing ${TEMP_DIR}/${WIDEVINE_FILENAME}"
-    if ! unzip -d ${TEMP_DIR} ${TEMP_DIR}/${WIDEVINE_FILENAME} ; then
+    echo "Installing ${WIDEVINE_TEMP_DIR}/${WIDEVINE_FILENAME}"
+    if ! unzip -d ${WIDEVINE_TEMP_DIR} ${WIDEVINE_TEMP_DIR}/${WIDEVINE_FILENAME} ; then
         echo "Cannot unpack zip file ${WIDEVINE_FILENAME}"
-    elif ! [ -f ${TEMP_DIR}/${WIDEVINE_SO_FILE} ]; then
+    elif ! [ -f ${WIDEVINE_TEMP_DIR}/${WIDEVINE_SO_FILE} ]; then
         echo "Could not find ${WIDEVINE_SO_FILE}"
-    elif ! install -m 644 ${TEMP_DIR}/${WIDEVINE_SO_FILE} ${DEST_DIR} ; then
+    elif ! install -m 644 ${WIDEVINE_TEMP_DIR}/${WIDEVINE_SO_FILE} ${DEST_DIR} ; then
         echo "Could not copy ${WIDEVINE_SO_FILE} into ${DEST_DIR}"
     else
         # Sanity check: don't ever write a VERSION file with an empty value


### PR DESCRIPTION
Both Flash's .tgz and Widevine's .zip ship a manifest.json file which
means that if this script downloads both of them, the latter attempt
fails because zip does not overwrite files by default. Tidy up / avoid
this case by using separate directories for the Flash and Widevine
download/install.

https://phabricator.endlessm.com/T21987