### PR TITLE
debian/control: Pull in the binutils package both for Intel and ARM

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Package: eos-chrome-plugin-updater
 Architecture: amd64 armhf
 Depends: ${misc:Depends},
 	${shlibs:Depends},
-	binutils [amd64],
+	binutils,
 	kpartx [armhf],
 	network-manager,
 	unzip,


### PR DESCRIPTION
We need the `strings` command in both cases due to the pepper API
flash plugin, so remove the [amd64] filter.

https://phabricator.endlessm.com/T23086