### PR TITLE
Remove hardcoded Flash plugin fallback URL

### DIFF
--- a/eos-chrome-plugin-update-upstream
+++ b/eos-chrome-plugin-update-upstream
@@ -26,10 +26,6 @@ WGET_COMMAND="wget -c --tries=5"
 DAYS_CHECK=7
 
 # Data needed for the Flash plugin, from Adobe
-FLASH_FALLBACK_VERSION="32.0.0.114"
-FLASH_FALLBACK_URL="https://fpdownload.adobe.com/pub/flashplayer/pdc/${FLASH_FALLBACK_VERSION}/flash_player_ppapi_linux.$(arch).tar.gz"
-FLASH_FALLBACK_SHA256SUM="deeb079c3c625603a3dff103ffc647f13876beae7a148abaa27eee86abcd8978"
-
 FLASH_LKGV_FILE_URL="https://s3-us-west-2.amazonaws.com/abacadaba/flashplugin-$(arch).lkgv"
 FLASH_LKGV_VERSION=
 FLASH_LKGV_URL=
@@ -168,11 +164,7 @@ fp_fetch_flash_metadata() {
         done < ${FLASH_TEMP_DIR}/${filename}
     else
         echo "Failed to retrieve the last known good version of the flash plugin"
-        echo "Using fallbacks values (Flash plugin version: ${FLASH_FALLBACK_VERSION})"
-
-        FLASH_LKGV_VERSION="${FLASH_FALLBACK_VERSION}"
-        FLASH_LKGV_SHA256SUM="${FLASH_FALLBACK_SHA256SUM}"
-        FLASH_LKGV_URL="${FLASH_FALLBACK_URL}"
+        return 1
     fi
 
     # This will be needed then downloading and installing

--- a/eos-chrome-plugin-update-upstream
+++ b/eos-chrome-plugin-update-upstream
@@ -163,7 +163,7 @@ fp_fetch_flash_metadata() {
             esac
         done < ${FLASH_TEMP_DIR}/${filename}
     else
-        echo "Failed to retrieve the last known good version of the flash plugin"
+        echo "Failed to retrieve the last known good version of the Flash plugin"
         return 1
     fi
 


### PR DESCRIPTION
Previously, if fetching the .lkgv file from the abacadaba S3 bucket
failed, we would fall back to downloading a hardcoded URL and checking
it against a hardcoded SHA256sum.

Technically, {users who can reach S3} ∩ {users who can reach Adobe's
server} ⊆ {users who can reach Adobe's server}, but I think the chances
of being able to reach Adobe's server (currently Akamai's CDN) but not
S3 are so slim as to not be worth worrying about, and so there is little
point in maintaining this fallback data. At best, it's not being used at
all; at worst, users will download an out-of-date copy of Flash or get a 404.

https://phabricator.endlessm.com/T24616