### PR TITLE
Install widevinecdm link on different paths for armhf and amd64.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,13 @@
+eos-chrome-plugin-updater (1.0.1-1) eos; urgency=low
+
+  * New upstream release 1.0.1
+  * Install widevinecdm link on different paths for armhf and amd64.
+    This is required to make widevine work with chromium >= 78 which searches
+    for the plugin on a platform specific path on amd64.
+    https://phabricator.endlessm.com/T27973
+
+ -- Andre Moreira Magalhaes <andre@endlessm.com>  Fri, 08 Nov 2019 11:41:37 -0300
+
 eos-chrome-plugin-updater (1.0.0-1) eos; urgency=low
 
   [ Juan A. Suarez Romero ]

--- a/debian/control
+++ b/debian/control
@@ -1,9 +1,10 @@
 Source: eos-chrome-plugin-updater
 Section: contrib/web
 Priority: optional
-Maintainer: Roddy Shuler <roddy@endlessm.com>
+Maintainer: Endless Team <emdev@endlessm.com>
 Build-Depends: debhelper (>= 9),
 	dh-autoreconf,
+	dh-exec,
 	dh-systemd,
 	pkg-config,
 	systemd

--- a/debian/links
+++ b/debian/links
@@ -1,1 +1,3 @@
-/var/lib/chromium-plugins-extra/eos-chrome-plugin-updater/libwidevinecdm.so /usr/lib/chromium-browser/libwidevinecdm.so
+#!/usr/bin/dh-exec
+[linux-amd64] /var/lib/chromium-plugins-extra/eos-chrome-plugin-updater/libwidevinecdm.so /usr/lib/chromium-browser/WidevineCdm/_platform_specific/linux_x64/libwidevinecdm.so
+[linux-armhf] /var/lib/chromium-plugins-extra/eos-chrome-plugin-updater/libwidevinecdm.so /usr/lib/chromium-browser/libwidevinecdm.so


### PR DESCRIPTION
This is required to make widevine work with chromium >= 78 which searches for the plugin on a platform specific path on amd64.

This should only be merged once chromium 78 is merged. Another approach is to patch chromium to search the plugin the old way but I believe that is more risky.

https://phabricator.endlessm.com/T27973